### PR TITLE
feat: add @strikemate/leaguesecretary-client package

### DIFF
--- a/packages/leaguesecretary-client/src/client.ts
+++ b/packages/leaguesecretary-client/src/client.ts
@@ -6,7 +6,7 @@ async function fetchLS<T>(path: string): Promise<T[]> {
   const res = await fetch(`${BASE_URL}${path}`);
   if (!res.ok) {
     throw new Error(
-      `LeagueSecretary API error: ${res.status} ${res.statusText} — ${path}`
+      `LeagueSecretary API error: ${res.status} ${res.statusText} - ${path}`
     );
   }
   const json = (await res.json()) as LSApiResponse<T>;
@@ -25,7 +25,7 @@ export async function fetchBowlerList(leagueId: number): Promise<LSBowler[]> {
 }
 
 // weekNumber is 1-based. Verify the exact query string key against the
-// live network tab — may be ?week= or ?WeekNum= or similar.
+// live network tab - may be ?week= or ?WeekNum= or similar.
 export async function fetchWeekScores(
   leagueId: number,
   weekNumber: number

--- a/packages/leaguesecretary-client/src/ls-types.ts
+++ b/packages/leaguesecretary-client/src/ls-types.ts
@@ -43,7 +43,7 @@ export interface LSBowler {
   HighScratchGame: number;
   HighScratchSeries: number;
   MostImproved: number;
-  BowlerPosition: number;       // 0 = sub, 1–4 = roster position
+  BowlerPosition: number;       // 0 = sub, 1-4 = roster position
   BowlerStatus: "R" | "T";     // R = regular, T = temporary/sub
   TeamNum: number;
   EnteringAverage: number;
@@ -73,7 +73,7 @@ export interface LSWeekScore {
   GameNum3: number;
   ScoreType3: LSScoreType;
   Score3: number;
-  // Games 4–6 exist in schema but are unused in standard 3-game leagues
+  // Games 4-6 exist in schema but are unused in standard 3-game leagues
   GameNum4: number;
   ScoreType4: LSScoreType;
   Score4: number;

--- a/packages/leaguesecretary-client/src/mapper.ts
+++ b/packages/leaguesecretary-client/src/mapper.ts
@@ -10,7 +10,7 @@ import type {
 } from "@strikemate/types";
 import type { LSBowler, LSTeamStanding, LSWeekScore } from "./ls-types.js";
 
-// LS stores names as "LastName, FirstName" — normalize to "FirstName LastName"
+// LS stores names as "LastName, FirstName" - normalize to "FirstName LastName"
 function normalizeName(lsName: string): string {
   const commaIndex = lsName.indexOf(", ");
   if (commaIndex === -1) return lsName;


### PR DESCRIPTION
## What

Adds the `@strikemate/leaguesecretary-client` package — a typed HTTP client for the LeagueSecretary.com API, which serves as the Phase 1 data source for the bowler app.

## Files

| File | Purpose |
|------|---------|
| `src/ls-types.ts` | Raw LS API response shapes (`LSBowler`, `LSTeamStanding`, `LSWeekScore`) |
| `src/client.ts` | Fetch functions for standings, bowler list, and weekly scores |
| `src/mapper.ts` | Converts LS types to `@strikemate/types` domain objects |
| `src/index.ts` | Barrel export |

## Notes

- The LS API is unauthenticated and returns JSON — no headless browser needed
- `BowlerStatus` is `"R"` (regular) or `"T"` (temporary/sub); `TeamID: 0` means unrostered
- `ScoreType` can be `"S"` (scratch), `"A"` (absent), `"I"` (incomplete), or `"0"` (unused slot)
- Absent bowlers have `SeriesTotal: 0` — they don't count toward team scratch
- `fetchWeekScores` query string param needs verification against live network tab (`?week=` vs `?WeekNum=`)
- Name normalization: LS stores `"LastName, FirstName"` — mapper converts to `"FirstName LastName"`