### PR TITLE
feat: scaffold apps/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@strikemate/api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@strikemate/leaguesecretary-client": "*",
+    "@strikemate/types": "*",
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.0",
+    "tsx": "^4.7.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,21 @@
+import cors from "cors";
+import express from "express";
+import { leagueRouter } from "./routes/league.js";
+
+const app = express();
+const PORT = process.env.PORT ?? 3001;
+
+app.use(cors());
+app.use(express.json());
+
+// Health check
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+// Routes
+app.use("/league", leagueRouter);
+
+app.listen(PORT, () => {
+  console.log(`StrikeMate API running on http://localhost:${PORT}`);
+});

--- a/apps/api/src/routes/league.ts
+++ b/apps/api/src/routes/league.ts
@@ -1,0 +1,74 @@
+import {
+  fetchBowlerList,
+  fetchStandings,
+  fetchWeekScores,
+  mapBowler,
+  mapSeries,
+  mapTeamStanding,
+} from "@strikemate/leaguesecretary-client";
+import type { LeagueId, WeekId } from "@strikemate/types";
+import { Router } from "express";
+
+export const leagueRouter = Router();
+
+// GET /league/:leagueId/standings
+// Returns current team standings mapped to domain types
+leagueRouter.get("/:leagueId/standings", async (req, res) => {
+  try {
+    const leagueId = Number(req.params.leagueId);
+    if (isNaN(leagueId)) {
+      res.status(400).json({ error: "Invalid leagueId" });
+      return;
+    }
+    const raw = await fetchStandings(leagueId);
+    const standings = raw.map((s) =>
+      mapTeamStanding(s, String(leagueId) as LeagueId)
+    );
+    res.json(standings);
+  } catch (err) {
+    console.error(err);
+    res.status(502).json({ error: "Failed to fetch standings from LeagueSecretary" });
+  }
+});
+
+// GET /league/:leagueId/bowlers
+// Returns full bowler list mapped to domain types
+leagueRouter.get("/:leagueId/bowlers", async (req, res) => {
+  try {
+    const leagueId = Number(req.params.leagueId);
+    if (isNaN(leagueId)) {
+      res.status(400).json({ error: "Invalid leagueId" });
+      return;
+    }
+    const raw = await fetchBowlerList(leagueId);
+    const bowlers = raw.map((b) =>
+      mapBowler(b, String(leagueId) as LeagueId)
+    );
+    res.json(bowlers);
+  } catch (err) {
+    console.error(err);
+    res.status(502).json({ error: "Failed to fetch bowlers from LeagueSecretary" });
+  }
+});
+
+// GET /league/:leagueId/scores/:weekNumber
+// Returns all bowler series for a given week mapped to domain types
+leagueRouter.get("/:leagueId/scores/:weekNumber", async (req, res) => {
+  try {
+    const leagueId = Number(req.params.leagueId);
+    const weekNumber = Number(req.params.weekNumber);
+    if (isNaN(leagueId) || isNaN(weekNumber)) {
+      res.status(400).json({ error: "Invalid leagueId or weekNumber" });
+      return;
+    }
+    const raw = await fetchWeekScores(leagueId, weekNumber);
+    const weekId = `${leagueId}-w${weekNumber}` as WeekId;
+    const series = raw.map((s) =>
+      mapSeries(s, String(leagueId) as LeagueId, weekId)
+    );
+    res.json(series);
+  } catch (err) {
+    console.error(err);
+    res.status(502).json({ error: "Failed to fetch scores from LeagueSecretary" });
+  }
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Scaffolds the `@strikemate/api` Express app — the backend that proxies LeagueSecretary data to the mobile app.

## Structure

```
apps/api/
  src/
    index.ts          — Express server entry point (port 3001)
    routes/
      league.ts       — League data routes
  package.json
  tsconfig.json
```

## Routes

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/health` | Health check |
| `GET` | `/league/:leagueId/standings` | Team standings |
| `GET` | `/league/:leagueId/bowlers` | Full bowler list |
| `GET` | `/league/:leagueId/scores/:weekNumber` | Bowler series for a given week |

## To run locally

```bash
cd apps/api
npm install
npm run dev
# API available at http://localhost:3001

# Test against your league:
curl http://localhost:3001/league/131919/standings
curl http://localhost:3001/league/131919/bowlers
curl http://localhost:3001/league/131919/scores/1
```

## Notes

- Uses `tsx` for dev (no build step needed locally)
- All routes map LS raw types to `@strikemate/types` domain objects before responding
- 502 errors propagate cleanly if LeagueSecretary is unreachable
- `weekNumber` query param format in `fetchWeekScores` still needs verification against live network tab