### PR TITLE
fix: correct LeagueSecretary API URL structure

### DIFF
--- a/apps/api/src/routes/league.ts
+++ b/apps/api/src/routes/league.ts
@@ -6,24 +6,44 @@ import {
   mapSeries,
   mapTeamStanding,
 } from "@strikemate/leaguesecretary-client";
+import type { LSLeagueRef } from "@strikemate/leaguesecretary-client";
 import type { LeagueId, WeekId } from "@strikemate/types";
 import { Router } from "express";
 
 export const leagueRouter = Router();
 
-// GET /league/:leagueId/standings
-// Returns current team standings mapped to domain types
-leagueRouter.get("/:leagueId/standings", async (req, res) => {
+/**
+ * All league routes require three query params that identify the league:
+ *   ?centerSlug=sun-coast-hotel-casino
+ *   &leagueSlug=sunday-fun-winter-2526
+ *   &leagueId=131919
+ *
+ * Example:
+ *   GET /league/standings?centerSlug=sun-coast-hotel-casino&leagueSlug=sunday-fun-winter-2526&leagueId=131919
+ */
+function parseLeagueRef(query: Record<string, unknown>): LSLeagueRef | null {
+  const { centerSlug, leagueSlug, leagueId } = query;
+  if (
+    typeof centerSlug !== "string" ||
+    typeof leagueSlug !== "string" ||
+    typeof leagueId !== "string" ||
+    isNaN(Number(leagueId))
+  ) {
+    return null;
+  }
+  return { centerSlug, leagueSlug, leagueId: Number(leagueId) };
+}
+
+// GET /league/standings?centerSlug=...&leagueSlug=...&leagueId=...
+leagueRouter.get("/standings", async (req, res) => {
+  const ref = parseLeagueRef(req.query as Record<string, unknown>);
+  if (!ref) {
+    res.status(400).json({ error: "Missing or invalid centerSlug, leagueSlug, or leagueId" });
+    return;
+  }
   try {
-    const leagueId = Number(req.params.leagueId);
-    if (isNaN(leagueId)) {
-      res.status(400).json({ error: "Invalid leagueId" });
-      return;
-    }
-    const raw = await fetchStandings(leagueId);
-    const standings = raw.map((s) =>
-      mapTeamStanding(s, String(leagueId) as LeagueId)
-    );
+    const raw = await fetchStandings(ref);
+    const standings = raw.map((s) => mapTeamStanding(s, String(ref.leagueId) as LeagueId));
     res.json(standings);
   } catch (err) {
     console.error(err);
@@ -31,19 +51,16 @@ leagueRouter.get("/:leagueId/standings", async (req, res) => {
   }
 });
 
-// GET /league/:leagueId/bowlers
-// Returns full bowler list mapped to domain types
-leagueRouter.get("/:leagueId/bowlers", async (req, res) => {
+// GET /league/bowlers?centerSlug=...&leagueSlug=...&leagueId=...
+leagueRouter.get("/bowlers", async (req, res) => {
+  const ref = parseLeagueRef(req.query as Record<string, unknown>);
+  if (!ref) {
+    res.status(400).json({ error: "Missing or invalid centerSlug, leagueSlug, or leagueId" });
+    return;
+  }
   try {
-    const leagueId = Number(req.params.leagueId);
-    if (isNaN(leagueId)) {
-      res.status(400).json({ error: "Invalid leagueId" });
-      return;
-    }
-    const raw = await fetchBowlerList(leagueId);
-    const bowlers = raw.map((b) =>
-      mapBowler(b, String(leagueId) as LeagueId)
-    );
+    const raw = await fetchBowlerList(ref);
+    const bowlers = raw.map((b) => mapBowler(b, String(ref.leagueId) as LeagueId));
     res.json(bowlers);
   } catch (err) {
     console.error(err);
@@ -51,21 +68,18 @@ leagueRouter.get("/:leagueId/bowlers", async (req, res) => {
   }
 });
 
-// GET /league/:leagueId/scores/:weekNumber
-// Returns all bowler series for a given week mapped to domain types
-leagueRouter.get("/:leagueId/scores/:weekNumber", async (req, res) => {
+// GET /league/scores/:weekNumber?centerSlug=...&leagueSlug=...&leagueId=...
+leagueRouter.get("/scores/:weekNumber", async (req, res) => {
+  const ref = parseLeagueRef(req.query as Record<string, unknown>);
+  const weekNumber = Number(req.params.weekNumber);
+  if (!ref || isNaN(weekNumber)) {
+    res.status(400).json({ error: "Missing or invalid params" });
+    return;
+  }
   try {
-    const leagueId = Number(req.params.leagueId);
-    const weekNumber = Number(req.params.weekNumber);
-    if (isNaN(leagueId) || isNaN(weekNumber)) {
-      res.status(400).json({ error: "Invalid leagueId or weekNumber" });
-      return;
-    }
-    const raw = await fetchWeekScores(leagueId, weekNumber);
-    const weekId = `${leagueId}-w${weekNumber}` as WeekId;
-    const series = raw.map((s) =>
-      mapSeries(s, String(leagueId) as LeagueId, weekId)
-    );
+    const raw = await fetchWeekScores(ref, weekNumber);
+    const weekId = `${ref.leagueId}-w${weekNumber}` as WeekId;
+    const series = raw.map((s) => mapSeries(s, String(ref.leagueId) as LeagueId, weekId));
     res.json(series);
   } catch (err) {
     console.error(err);

--- a/packages/leaguesecretary-client/src/client.ts
+++ b/packages/leaguesecretary-client/src/client.ts
@@ -1,34 +1,44 @@
-import type { LSApiResponse, LSBowler, LSTeamStanding, LSWeekScore } from "./ls-types.js";
+import type { LSApiResponse, LSBowler, LSLeagueRef, LSTeamStanding, LSWeekScore } from "./ls-types.js";
 
-const BASE_URL = "https://www.leaguesecretary.com/api";
+const BASE_URL = "https://www.leaguesecretary.com";
 
-async function fetchLS<T>(path: string): Promise<T[]> {
-  const res = await fetch(`${BASE_URL}${path}`);
+/**
+ * Builds the base path for a league:
+ *   /bowling-centers/{centerSlug}/bowling-leagues/{leagueSlug}
+ */
+function leaguePath(ref: LSLeagueRef): string {
+  return `/bowling-centers/${ref.centerSlug}/bowling-leagues/${ref.leagueSlug}`;
+}
+
+async function fetchLS<T>(url: string): Promise<T[]> {
+  const res = await fetch(url);
   if (!res.ok) {
     throw new Error(
-      `LeagueSecretary API error: ${res.status} ${res.statusText} - ${path}`
+      `LeagueSecretary API error: ${res.status} ${res.statusText} - ${url}`
     );
   }
   const json = (await res.json()) as LSApiResponse<T>;
   if (json.Errors !== null) {
-    throw new Error(`LeagueSecretary API returned errors for ${path}`);
+    throw new Error(`LeagueSecretary API returned errors for ${url}`);
   }
   return json.Data;
 }
 
-export async function fetchStandings(leagueId: number): Promise<LSTeamStanding[]> {
-  return fetchLS<LSTeamStanding>(`/league/standings/${leagueId}`);
+export async function fetchStandings(ref: LSLeagueRef): Promise<LSTeamStanding[]> {
+  const url = `${BASE_URL}${leaguePath(ref)}/league/standings/${ref.leagueId}`;
+  return fetchLS<LSTeamStanding>(url);
 }
 
-export async function fetchBowlerList(leagueId: number): Promise<LSBowler[]> {
-  return fetchLS<LSBowler>(`/league/bowlerlist/${leagueId}`);
+export async function fetchBowlerList(ref: LSLeagueRef): Promise<LSBowler[]> {
+  const url = `${BASE_URL}${leaguePath(ref)}/bowler/list/${ref.leagueId}`;
+  return fetchLS<LSBowler>(url);
 }
 
-// weekNumber is 1-based. Verify the exact query string key against the
-// live network tab - may be ?week= or ?WeekNum= or similar.
+// weekNumber is 1-based.
 export async function fetchWeekScores(
-  leagueId: number,
+  ref: LSLeagueRef,
   weekNumber: number
 ): Promise<LSWeekScore[]> {
-  return fetchLS<LSWeekScore>(`/league/summary/${leagueId}?week=${weekNumber}`);
+  const url = `${BASE_URL}${leaguePath(ref)}/league/summary/${ref.leagueId}?week=${weekNumber}`;
+  return fetchLS<LSWeekScore>(url);
 }

--- a/packages/leaguesecretary-client/src/ls-types.ts
+++ b/packages/leaguesecretary-client/src/ls-types.ts
@@ -8,6 +8,22 @@ export interface LSApiResponse<T> {
   Errors: null;
 }
 
+/**
+ * The slugs needed to construct any LeagueSecretary URL.
+ * These appear in every page URL:
+ *   /bowling-centers/{centerSlug}/bowling-leagues/{leagueSlug}/{section}/{leagueId}
+ *
+ * Example for Sunday Fun Winter 25-26:
+ *   centerSlug: "sun-coast-hotel-casino"
+ *   leagueSlug: "sunday-fun-winter-2526"
+ *   leagueId:   131919
+ */
+export interface LSLeagueRef {
+  centerSlug: string;
+  leagueSlug: string;
+  leagueId: number;
+}
+
 export interface LSTeamStanding {
   TeamID: number;
   TeamNum: number;


### PR DESCRIPTION
## Problem

The LS API URLs are not at `/api/league/...` — they follow the full slug pattern from the page URLs:

```
/bowling-centers/{centerSlug}/bowling-leagues/{leagueSlug}/{section}/{leagueId}
```

## Changes

**`packages/leaguesecretary-client/src/ls-types.ts`**
- Added `LSLeagueRef` — carries the three pieces needed to construct any LS URL: `centerSlug`, `leagueSlug`, `leagueId`

**`packages/leaguesecretary-client/src/client.ts`**
- Updated `BASE_URL` to `https://www.leaguesecretary.com` (no `/api`)
- All fetch functions now take `LSLeagueRef` instead of bare `leagueId`
- Corrected endpoint paths based on confirmed URLs

**`apps/api/src/routes/league.ts`**
- Routes now take `centerSlug`, `leagueSlug`, `leagueId` as query params instead of path params
- Added `parseLeagueRef` helper to validate and assemble the ref

## Testing

After merging and restarting the API:

```bash
BASE="centerSlug=sun-coast-hotel-casino&leagueSlug=sunday-fun-winter-2526&leagueId=131919"

curl "http://localhost:3001/league/standings?$BASE"
curl "http://localhost:3001/league/bowlers?$BASE"
curl "http://localhost:3001/league/scores/1?$BASE"
```