### PR TITLE
fix: switch LS client to POST with form-encoded body

### DIFF
--- a/apps/api/src/routes/league.ts
+++ b/apps/api/src/routes/league.ts
@@ -13,32 +13,38 @@ import { Router } from "express";
 export const leagueRouter = Router();
 
 /**
- * All league routes require three query params that identify the league:
- *   ?centerSlug=sun-coast-hotel-casino
- *   &leagueSlug=sunday-fun-winter-2526
- *   &leagueId=131919
+ * All league routes require these query params:
+ *   ?leagueId=131919&year=2025&season=f&weekNum=26
  *
  * Example:
- *   GET /league/standings?centerSlug=sun-coast-hotel-casino&leagueSlug=sunday-fun-winter-2526&leagueId=131919
+ *   GET /league/standings?leagueId=131919&year=2025&season=f&weekNum=26
  */
 function parseLeagueRef(query: Record<string, unknown>): LSLeagueRef | null {
-  const { centerSlug, leagueSlug, leagueId } = query;
+  const { leagueId, year, season, weekNum } = query;
   if (
-    typeof centerSlug !== "string" ||
-    typeof leagueSlug !== "string" ||
     typeof leagueId !== "string" ||
-    isNaN(Number(leagueId))
+    typeof year !== "string" ||
+    typeof season !== "string" ||
+    typeof weekNum !== "string" ||
+    isNaN(Number(leagueId)) ||
+    isNaN(Number(year)) ||
+    isNaN(Number(weekNum))
   ) {
     return null;
   }
-  return { centerSlug, leagueSlug, leagueId: Number(leagueId) };
+  return {
+    leagueId: Number(leagueId),
+    year: Number(year),
+    season,
+    weekNum: Number(weekNum),
+  };
 }
 
-// GET /league/standings?centerSlug=...&leagueSlug=...&leagueId=...
+// GET /league/standings?leagueId=131919&year=2025&season=f&weekNum=26
 leagueRouter.get("/standings", async (req, res) => {
   const ref = parseLeagueRef(req.query as Record<string, unknown>);
   if (!ref) {
-    res.status(400).json({ error: "Missing or invalid centerSlug, leagueSlug, or leagueId" });
+    res.status(400).json({ error: "Required query params: leagueId, year, season, weekNum" });
     return;
   }
   try {
@@ -51,11 +57,11 @@ leagueRouter.get("/standings", async (req, res) => {
   }
 });
 
-// GET /league/bowlers?centerSlug=...&leagueSlug=...&leagueId=...
+// GET /league/bowlers?leagueId=131919&year=2025&season=f&weekNum=26
 leagueRouter.get("/bowlers", async (req, res) => {
   const ref = parseLeagueRef(req.query as Record<string, unknown>);
   if (!ref) {
-    res.status(400).json({ error: "Missing or invalid centerSlug, leagueSlug, or leagueId" });
+    res.status(400).json({ error: "Required query params: leagueId, year, season, weekNum" });
     return;
   }
   try {
@@ -68,12 +74,12 @@ leagueRouter.get("/bowlers", async (req, res) => {
   }
 });
 
-// GET /league/scores/:weekNumber?centerSlug=...&leagueSlug=...&leagueId=...
+// GET /league/scores/:weekNumber?leagueId=131919&year=2025&season=f&weekNum=26
 leagueRouter.get("/scores/:weekNumber", async (req, res) => {
   const ref = parseLeagueRef(req.query as Record<string, unknown>);
   const weekNumber = Number(req.params.weekNumber);
   if (!ref || isNaN(weekNumber)) {
-    res.status(400).json({ error: "Missing or invalid params" });
+    res.status(400).json({ error: "Required query params: leagueId, year, season, weekNum" });
     return;
   }
   try {

--- a/packages/leaguesecretary-client/src/client.ts
+++ b/packages/leaguesecretary-client/src/client.ts
@@ -3,42 +3,68 @@ import type { LSApiResponse, LSBowler, LSLeagueRef, LSTeamStanding, LSWeekScore 
 const BASE_URL = "https://www.leaguesecretary.com";
 
 /**
- * Builds the base path for a league:
- *   /bowling-centers/{centerSlug}/bowling-leagues/{leagueSlug}
+ * Posts form-encoded data to a Kendo UI Read endpoint and returns Data[].
+ * All LS data endpoints follow this pattern.
  */
-function leaguePath(ref: LSLeagueRef): string {
-  return `/bowling-centers/${ref.centerSlug}/bowling-leagues/${ref.leagueSlug}`;
-}
+async function postLS<T>(path: string, body: Record<string, string | number>): Promise<T[]> {
+  const form = new URLSearchParams();
+  // Kendo UI grid always sends these pagination/sort params
+  form.set("sort", "");
+  form.set("page", "1");
+  form.set("pageSize", "1000");
+  form.set("group", "");
+  form.set("filter", "");
+  // Endpoint-specific params
+  for (const [key, value] of Object.entries(body)) {
+    form.set(key, String(value));
+  }
 
-async function fetchLS<T>(url: string): Promise<T[]> {
-  const res = await fetch(url);
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: form.toString(),
+  });
+
   if (!res.ok) {
     throw new Error(
-      `LeagueSecretary API error: ${res.status} ${res.statusText} - ${url}`
+      `LeagueSecretary API error: ${res.status} ${res.statusText} - ${path}`
     );
   }
+
   const json = (await res.json()) as LSApiResponse<T>;
   if (json.Errors !== null) {
-    throw new Error(`LeagueSecretary API returned errors for ${url}`);
+    throw new Error(`LeagueSecretary API returned errors for ${path}`);
   }
   return json.Data;
 }
 
 export async function fetchStandings(ref: LSLeagueRef): Promise<LSTeamStanding[]> {
-  const url = `${BASE_URL}${leaguePath(ref)}/league/standings/${ref.leagueId}`;
-  return fetchLS<LSTeamStanding>(url);
+  return postLS<LSTeamStanding>("/League/InteractiveStandings_Read", {
+    leagueId: ref.leagueId,
+    year: ref.year,
+    season: ref.season,
+    weekNum: ref.weekNum,
+  });
 }
 
+// TODO: update once bowler list and summary endpoint names are confirmed from DevTools
 export async function fetchBowlerList(ref: LSLeagueRef): Promise<LSBowler[]> {
-  const url = `${BASE_URL}${leaguePath(ref)}/bowler/list/${ref.leagueId}`;
-  return fetchLS<LSBowler>(url);
+  return postLS<LSBowler>("/League/BowlerList_Read", {
+    leagueId: ref.leagueId,
+    year: ref.year,
+    season: ref.season,
+    weekNum: ref.weekNum,
+  });
 }
 
-// weekNumber is 1-based.
 export async function fetchWeekScores(
   ref: LSLeagueRef,
   weekNumber: number
 ): Promise<LSWeekScore[]> {
-  const url = `${BASE_URL}${leaguePath(ref)}/league/summary/${ref.leagueId}?week=${weekNumber}`;
-  return fetchLS<LSWeekScore>(url);
+  return postLS<LSWeekScore>("/League/Summary_Read", {
+    leagueId: ref.leagueId,
+    year: ref.year,
+    season: ref.season,
+    weekNum: weekNumber,
+  });
 }

--- a/packages/leaguesecretary-client/src/ls-types.ts
+++ b/packages/leaguesecretary-client/src/ls-types.ts
@@ -9,19 +9,17 @@ export interface LSApiResponse<T> {
 }
 
 /**
- * The slugs needed to construct any LeagueSecretary URL.
- * These appear in every page URL:
- *   /bowling-centers/{centerSlug}/bowling-leagues/{leagueSlug}/{section}/{leagueId}
- *
- * Example for Sunday Fun Winter 25-26:
- *   centerSlug: "sun-coast-hotel-casino"
- *   leagueSlug: "sunday-fun-winter-2526"
- *   leagueId:   131919
+ * Identifies a league on LeagueSecretary.
+ * leagueId:   the numeric ID (e.g. 131919)
+ * year:       the season start year (e.g. 2025 for the 2025-26 season)
+ * season:     "f" for fall/winter, "s" for spring/summer (observed: "f")
+ * weekNum:    current/latest week number — used as default for score fetches
  */
 export interface LSLeagueRef {
-  centerSlug: string;
-  leagueSlug: string;
   leagueId: number;
+  year: number;
+  season: string;
+  weekNum: number;
 }
 
 export interface LSTeamStanding {


### PR DESCRIPTION
## Problem

LS data endpoints are Kendo UI `_Read` actions — they require `POST` with `application/x-www-form-urlencoded` body, not GET requests.

## Confirmed endpoint (from DevTools)
```
POST https://www.leaguesecretary.com/League/InteractiveStandings_Read

Body:
  sort=&page=1&pageSize=1000&group=&filter=
  &leagueId=131919&year=2025&season=f&weekNum=26
```

## Changes

**`ls-types.ts`** — `LSLeagueRef` simplified to just the params the API needs: `leagueId`, `year`, `season`, `weekNum`. No more URL slugs.

**`client.ts`** — Replaced `fetch GET` with `postLS()` which builds a form-encoded body with the standard Kendo pagination params + endpoint-specific params.

**`routes/league.ts`** — Updated query params to match: `?leagueId=131919&year=2025&season=f&weekNum=26`

## ⚠️ Still needs verification

`fetchBowlerList` and `fetchWeekScores` endpoint paths are best guesses. Need DevTools confirmation from the Bowler List and Summary pages.

## Testing

After merging, restart the API and hit:
```bash
curl "http://localhost:3001/league/standings?leagueId=131919&year=2025&season=f&weekNum=26"
```